### PR TITLE
add alpha option for background color

### DIFF
--- a/src/css/themes.styl
+++ b/src/css/themes.styl
@@ -48,19 +48,14 @@
   // Other theme colors
 
   &.iziToast-color-red
-    background rgba(255, 175, 180, 0.9)
     border-color rgba(255, 175, 180, 0.9)
   &.iziToast-color-orange
-    background rgba(255, 207, 165, 0.9)
     border-color rgba(255, 207, 165, 0.9)
   &.iziToast-color-yellow
-    background rgba(255, 249, 178, 0.9)
     border-color rgba(255, 249, 178, 0.9)
   &.iziToast-color-blue
-    background rgba(157, 222, 255, 0.9)
     border-color rgba(157, 222, 255, 0.9)
   &.iziToast-color-green
-    background rgba(166, 239, 184, 0.9)
     border-color rgba(166, 239, 184, 0.9)
   
   /*

--- a/src/js/iziToast.js
+++ b/src/js/iziToast.js
@@ -29,23 +29,28 @@
 		THEMES = {
 			info: {
 				color: 'blue',
-				icon: 'ico-info'
+				icon: 'ico-info',
+				backgroundColor: "rgba(157, 222, 255, 1)",
 			},
 			success: {
 				color: 'green',
-				icon: 'ico-success'
+				icon: 'ico-success',
+				backgroundColor: "rgba(166, 239, 184, 1)",
 			},
 			warning: {
 				color: 'orange',
-				icon: 'ico-warning'
+				icon: 'ico-warning',
+				backgroundColor: "rgba(255, 207, 165, 1)",
 			},
 			error: {
 				color: 'red',
-				icon: 'ico-error'
+				icon: 'ico-error',
+				backgroundColor: "rgba(255, 175, 180, 1)",
 			},
 			question: {
 				color: 'yellow',
-				icon: 'ico-question'
+				icon: 'ico-question',
+				backgroundColor: "rgba(255, 249, 178, 1)",
 			}
 		},
 		MOBILEWIDTH = 568,
@@ -66,6 +71,7 @@
 		messageSize: '',
 		messageLineHeight: '',
 		backgroundColor: '',
+		backgroundOpacity: '1',
 		theme: 'light', // dark
 		color: '', // blue, red, green, yellow
 		icon: '',
@@ -219,6 +225,10 @@
 		} else {
 			return false;
 		}
+	};
+	
+	var isRgba = function(color){
+		return color.substring(0,4) == 'rgba';
 	};
 
 
@@ -777,7 +787,11 @@
 			}
 
 			if(settings.backgroundColor) {
-				$DOM.toast.style.background = settings.backgroundColor;
+				if (isRgba(settings.backgroundColor)) {
+					$DOM.toast.style.background = settings.backgroundColor.slice(0, -2) + settings.backgroundOpacity + ')';
+				} else {
+					$DOM.toast.style.background = settings.backgroundColor;
+				}
 				if(settings.balloon){
 					$DOM.toast.style.borderColor = settings.backgroundColor;				
 				}


### PR DESCRIPTION
Unfortunately I couldn't change opacity for `info`, `success`, `warning`, `error` and `question` without system theme changing or create new one witch was the same as system with little alpha changes.

With new field "backgroundOpacity" everyone can change opacity for default theme or any other background color