### PR TITLE
Added CDN support to make it easier to import this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ gulp watch
 ```
 ___
 
-
+### CDN
+```html
+<script src="https://cdn.jsdelivr.net/gh/marcelodolza/iziToast/dist/js/iziToast.min.js"></script>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/marcelodolza/iziToast/dist/css/iziToast.min.css">
+```
 #### [NPM](https://www.npmjs.com/package/izitoast)
 ```
 npm install izitoast --save


### PR DESCRIPTION
Added a CDN option to integrate the library directly into sites without the requirement of running any command or downloading anything.

Free CDN provided by jsDelivr (https://www.jsdelivr.com/).